### PR TITLE
update initial migration with non-deprecated IP field

### DIFF
--- a/dialogos/migrations/0001_initial.py
+++ b/dialogos/migrations/0001_initial.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
                 ('object_id', models.IntegerField()),
                 ('comment', models.TextField()),
                 ('submit_date', models.DateTimeField(default=datetime.datetime.now)),
-                ('ip_address', models.IPAddressField(null=True)),
+                ('ip_address', models.GenericIPAddressField(null=True)),
                 ('public', models.BooleanField(default=True)),
                 ('author', models.ForeignKey(related_name='comments', to=settings.AUTH_USER_MODEL, null=True)),
                 ('content_type', models.ForeignKey(to='contenttypes.ContentType')),


### PR DESCRIPTION
@jj0hns0n you're too fast! ;-) 

Very sorry: forgot to add a migration update to previous PR.

Ref: https://github.com/GeoNode/geonode-dialogos/pull/2
