### PR TITLE
version bump for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from distutils.core import setup
 
 setup(
     name = "dialogos",
-    version = "0.4",
+    version = "0.6",
     author = "Eldarion",
     author_email = "development@eldarion.com",
     description = "a flaggable comments app",
     long_description = open("README.rst").read(),
     license = "BSD",
-    url = "http://github.com/eldarion/dialogos",
+    url = "https://github.com/GeoNode/geonode-dialogos",
     packages = [
         "dialogos",
         "dialogos.templatetags",


### PR DESCRIPTION
Bumped to 0.6 since PyPI already has a 0.5 (not tracked in repo); fixed github URL too.

Also @jj0hns0n do you want to add yourself as maintainer contact on this in setup.py?

I've created a release tag for this on my fork (https://github.com/sarasafavi/geonode-dialogos/releases/tag/0.6) but my github fu is failing, so if it's fine I'll just push the tag here directly without any PR-like approval for said tag.
